### PR TITLE
Add MCP server implementation

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -1,0 +1,316 @@
+# MCP Server Documentation
+
+## Overview
+
+The MCP (Model Context Protocol) Server is a lightweight HTTP server implementation that provides a standardized protocol for MCP-compatible clients to interact with the GantuGo service.
+
+## Starting the Server
+
+To start the MCP server, run:
+
+```bash
+go run main.go mcpServer
+```
+
+Or using the compiled binary:
+
+```bash
+./main mcpServer
+```
+
+The server will start on the port specified in your environment configuration (loaded via `PORT` environment variable).
+
+## Architecture
+
+The MCP server is implemented in `internal/server/mcpServer.go` and follows the Model Context Protocol specification. It provides a clean JSON-based API for client-server communication.
+
+### Key Components
+
+- **MCPRequest**: Standard request structure containing method, parameters, and optional ID
+- **MCPResponse**: Standard response structure with result or error, and request ID
+- **MCPError**: Error structure following JSON-RPC 2.0 error codes
+
+## Endpoints
+
+### 1. Health Check
+
+**Endpoint**: `GET /health`
+
+**Description**: Health check endpoint to verify server status
+
+**Response**:
+```json
+{
+  "status": "healthy",
+  "service": "MCP Server",
+  "time": 1234567890
+}
+```
+
+**Example**:
+```bash
+curl http://localhost:8080/health
+```
+
+---
+
+### 2. Server Info
+
+**Endpoint**: `GET /info`
+
+**Description**: Provides information about the MCP server
+
+**Response**:
+```json
+{
+  "name": "GantuGo MCP Server",
+  "version": "1.0.0",
+  "protocol": "MCP",
+  "description": "Model Context Protocol server implementation"
+}
+```
+
+**Example**:
+```bash
+curl http://localhost:8080/info
+```
+
+---
+
+### 3. MCP Protocol Endpoint
+
+**Endpoint**: `POST /mcp`
+
+**Description**: Main MCP protocol endpoint for handling method calls
+
+**Request Format**:
+```json
+{
+  "method": "methodName",
+  "params": {
+    "key": "value"
+  },
+  "id": "optional-request-id"
+}
+```
+
+**Response Format (Success)**:
+```json
+{
+  "result": {
+    "data": "response data"
+  },
+  "id": "optional-request-id"
+}
+```
+
+**Response Format (Error)**:
+```json
+{
+  "error": {
+    "code": -32601,
+    "message": "Method not found: methodName"
+  },
+  "id": "optional-request-id"
+}
+```
+
+## Supported Methods
+
+### 1. ping
+
+**Description**: Simple ping method to test connectivity
+
+**Request**:
+```json
+{
+  "method": "ping",
+  "id": "1"
+}
+```
+
+**Response**:
+```json
+{
+  "result": {
+    "message": "pong"
+  },
+  "id": "1"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"ping","id":"1"}'
+```
+
+---
+
+### 2. echo
+
+**Description**: Echoes back the parameters sent in the request
+
+**Request**:
+```json
+{
+  "method": "echo",
+  "params": {
+    "message": "Hello, MCP!",
+    "timestamp": 1234567890
+  },
+  "id": "2"
+}
+```
+
+**Response**:
+```json
+{
+  "result": {
+    "message": "Hello, MCP!",
+    "timestamp": 1234567890
+  },
+  "id": "2"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"echo","params":{"message":"Hello"},"id":"2"}'
+```
+
+---
+
+### 3. getContext
+
+**Description**: Returns context information along with the provided parameters
+
+**Request**:
+```json
+{
+  "method": "getContext",
+  "params": {
+    "key": "value"
+  },
+  "id": "3"
+}
+```
+
+**Response**:
+```json
+{
+  "result": {
+    "context": "MCP server context",
+    "params": {
+      "key": "value"
+    }
+  },
+  "id": "3"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"getContext","params":{"user":"test"},"id":"3"}'
+```
+
+## Error Codes
+
+The MCP server follows JSON-RPC 2.0 error code conventions:
+
+| Code | Message | Description |
+|------|---------|-------------|
+| -32700 | Parse error | Invalid JSON was received by the server |
+| -32601 | Method not found | The requested method does not exist |
+
+## Server Configuration
+
+### Timeouts
+
+The server is configured with the following timeouts:
+
+- **Read Timeout**: 15 seconds
+- **Write Timeout**: 15 seconds
+- **Idle Timeout**: 60 seconds
+
+### Port Configuration
+
+The server port is configured via environment variables. Ensure the `PORT` environment variable is set in your `.env.test`, `.env.prod`, or `.env.local` file.
+
+## Testing
+
+You can test the MCP server using the provided `testRequest.http` file with the REST Client extension in VSCode, or use `curl` commands as shown in the examples above.
+
+### Example Test Sequence
+
+1. Check server health:
+```bash
+curl http://localhost:8080/health
+```
+
+2. Get server info:
+```bash
+curl http://localhost:8080/info
+```
+
+3. Test ping method:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"ping","id":"1"}'
+```
+
+4. Test echo method:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"echo","params":{"test":"data"},"id":"2"}'
+```
+
+5. Test getContext method:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method":"getContext","params":{"user":"example"},"id":"3"}'
+```
+
+## Integration
+
+To integrate the MCP server into your application:
+
+1. Import the server package:
+```go
+import "main/internal/server"
+```
+
+2. Start the server:
+```go
+server.Start()
+```
+
+The server will run as a blocking call, so you may want to run it in a goroutine if you need to perform other operations:
+
+```go
+go server.Start()
+```
+
+## Future Enhancements
+
+Potential areas for expansion:
+
+- Additional MCP methods for domain-specific functionality
+- Authentication and authorization
+- WebSocket support for real-time communication
+- Request logging and metrics
+- Rate limiting
+- API versioning
+
+## References
+
+- Model Context Protocol (MCP) specification
+- JSON-RPC 2.0 specification

--- a/internal/server/mcpServer.go
+++ b/internal/server/mcpServer.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"main/internal/utils"
+	"net/http"
+	"time"
+)
+
+/*
+MCP (Model Context Protocol) Server implementation.
+This server provides endpoints for MCP-compatible clients to interact with the service.
+*/
+
+// MCPRequest represents a standard MCP request structure
+type MCPRequest struct {
+	Method string                 `json:"method"`
+	Params map[string]interface{} `json:"params,omitempty"`
+	ID     string                 `json:"id,omitempty"`
+}
+
+// MCPResponse represents a standard MCP response structure
+type MCPResponse struct {
+	Result interface{} `json:"result,omitempty"`
+	Error  *MCPError   `json:"error,omitempty"`
+	ID     string      `json:"id,omitempty"`
+}
+
+// MCPError represents an error in MCP protocol
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Start initializes and starts the MCP server
+func Start() {
+	mux := http.NewServeMux()
+
+	// Health check endpoint
+	mux.HandleFunc("GET /health", handleHealth)
+
+	// MCP protocol endpoint
+	mux.HandleFunc("POST /mcp", handleMCPRequest)
+
+	// Server info endpoint
+	mux.HandleFunc("GET /info", handleInfo)
+
+	// Catch-all for undefined routes
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "404 - MCP endpoint not found", http.StatusNotFound)
+	})
+
+	port := ":" + utils.LoadPort()
+
+	server := &http.Server{
+		Addr:         port,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	log.Printf("MCP Server started on %s", port)
+	log.Fatal(server.ListenAndServe())
+}
+
+// handleHealth handles health check requests
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":  "healthy",
+		"service": "MCP Server",
+		"time":    time.Now().Unix(),
+	})
+}
+
+// handleInfo provides server information
+func handleInfo(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"name":        "GantuGo MCP Server",
+		"version":     "1.0.0",
+		"protocol":    "MCP",
+		"description": "Model Context Protocol server implementation",
+	})
+}
+
+// handleMCPRequest processes MCP protocol requests
+func handleMCPRequest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req MCPRequest
+	decoder := json.NewDecoder(r.Body)
+	defer r.Body.Close()
+
+	if err := decoder.Decode(&req); err != nil {
+		sendError(w, &MCPError{
+			Code:    -32700,
+			Message: fmt.Sprintf("Parse error: %v", err),
+		}, "")
+		return
+	}
+
+	// Route based on method
+	switch req.Method {
+	case "ping":
+		sendResult(w, map[string]string{"message": "pong"}, req.ID)
+	case "echo":
+		sendResult(w, req.Params, req.ID)
+	case "getContext":
+		sendResult(w, map[string]interface{}{
+			"context": "MCP server context",
+			"params":  req.Params,
+		}, req.ID)
+	default:
+		sendError(w, &MCPError{
+			Code:    -32601,
+			Message: fmt.Sprintf("Method not found: %s", req.Method),
+		}, req.ID)
+	}
+}
+
+// sendResult sends a successful MCP response
+func sendResult(w http.ResponseWriter, result interface{}, id string) {
+	response := MCPResponse{
+		Result: result,
+		ID:     id,
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// sendError sends an error MCP response
+func sendError(w http.ResponseWriter, err *MCPError, id string) {
+	response := MCPResponse{
+		Error: err,
+		ID:    id,
+	}
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(response)
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ func main() {
 		server.Server()
 	case "chiServer":
 		server.CreateChiServer()
+	case "mcpServer":
+		server.Start()
 	case "utils":
 		utils.LoadEnvVariables()
 	default:


### PR DESCRIPTION
Implements MCP server as requested in issue #7

### Changes
- Created `internal/server/mcpServer.go` with `Start()` method
- Implemented MCP protocol endpoints: health, info, and mcp
- Added support for ping, echo, and getContext methods
- Integrated MCP server into main.go with mcpServer argument

Closes #7

---
Generated with [Claude Code](https://claude.ai/code)